### PR TITLE
License exception fix when info is not available

### DIFF
--- a/lib/omniauth/strategies/saml-rmunify.rb
+++ b/lib/omniauth/strategies/saml-rmunify.rb
@@ -54,7 +54,7 @@ module OmniAuth
       end
 
       def licence_description(licence)
-        if (licence.nil != true) then
+        if (licence.nil? != true) then
           desc = licence['description'].split('/')
           {
             :app_name     => desc[0],

--- a/lib/omniauth/strategies/saml-rmunify.rb
+++ b/lib/omniauth/strategies/saml-rmunify.rb
@@ -39,23 +39,30 @@ module OmniAuth
 
       def licence
         licence_str =  @attributes['http://schemas.rm.com/identity/claims/applicence']
-        licence = Hash[licence_str[1..-2].split('|').map{|kv|
-          (k,v) = kv.split(':')
-          [k.underscore, v]
-        }]
-        licence['is_trial'] = licence['is_trial'] == 'True'
-        licence['is_connector'] = licence['is_connector'] == 'True'
-        licence.merge!(licence_description(licence))
+        if defined?(licence_str) && (licence_str.nil? != true) then
+          licence = Hash[licence_str[1..-2].split('|').map{|kv|
+            (k,v) = kv.split(':')
+            [k.underscore, v]
+          }]
+          licence['is_trial'] = licence['is_trial'] == 'True'
+          licence['is_connector'] = licence['is_connector'] == 'True'
+          licence.merge!(licence_description(licence))
+        elsif 
+          Rails.logger.debug("Licensing information is not available!")
+          licence = nil
+        end
       end
 
       def licence_description(licence)
-        desc = licence['description'].split('/')
-        {
-          :app_name     => desc[0],
-          :package_name => desc[1],
-          :school_type  => desc[2],
-          :term         => desc[3]
-        }
+        if (licence.nil != true) then
+          desc = licence['description'].split('/')
+          {
+            :app_name     => desc[0],
+            :package_name => desc[1],
+            :school_type  => desc[2],
+            :term         => desc[3]
+          }
+        end
       end
     end
   end

--- a/lib/omniauth/strategies/saml-rmunify.rb
+++ b/lib/omniauth/strategies/saml-rmunify.rb
@@ -39,7 +39,7 @@ module OmniAuth
 
       def licence
         licence_str =  @attributes['http://schemas.rm.com/identity/claims/applicence']
-        if defined?(licence_str) && (licence_str.nil? != true) then
+        unless licence_str.nil?
           licence = Hash[licence_str[1..-2].split('|').map{|kv|
             (k,v) = kv.split(':')
             [k.underscore, v]
@@ -47,22 +47,17 @@ module OmniAuth
           licence['is_trial'] = licence['is_trial'] == 'True'
           licence['is_connector'] = licence['is_connector'] == 'True'
           licence.merge!(licence_description(licence))
-        elsif 
-          Rails.logger.debug("Licensing information is not available!")
-          licence = nil
         end
       end
 
       def licence_description(licence)
-        if (licence.nil? != true) then
-          desc = licence['description'].split('/')
-          {
-            :app_name     => desc[0],
-            :package_name => desc[1],
-            :school_type  => desc[2],
-            :term         => desc[3]
-          }
-        end
+        desc = licence['description'].split('/')
+        {
+          :app_name     => desc[0],
+          :package_name => desc[1],
+          :school_type  => desc[2],
+          :term         => desc[3]
+        }
       end
     end
   end

--- a/lib/omniauth/strategies/saml-rmunify.rb
+++ b/lib/omniauth/strategies/saml-rmunify.rb
@@ -39,15 +39,14 @@ module OmniAuth
 
       def licence
         licence_str =  @attributes['http://schemas.rm.com/identity/claims/applicence']
-        unless licence_str.nil?
-          licence = Hash[licence_str[1..-2].split('|').map{|kv|
-            (k,v) = kv.split(':')
-            [k.underscore, v]
-          }]
-          licence['is_trial'] = licence['is_trial'] == 'True'
-          licence['is_connector'] = licence['is_connector'] == 'True'
-          licence.merge!(licence_description(licence))
-        end
+        return nil if licence_str.nil? || licence_str.empty?
+        licence = Hash[licence_str[1..-2].split('|').map{|kv|
+          (k,v) = kv.split(':')
+          [k.underscore, v]
+        }]
+        licence['is_trial'] = licence['is_trial'] == 'True'
+        licence['is_connector'] = licence['is_connector'] == 'True'
+        licence.merge!(licence_description(licence))
       end
 
       def licence_description(licence)


### PR DESCRIPTION
Fellow Hampei,

I’ve fixed an exception in license parse logic which happens when information on AppLicense (that is optional and not always available) makes your gem useless. 

According to the information on RM Unify Dashboard for SSO, the following parameters are optional and not always available on callback page: 

AppLicence      http://schemas.rm.com/identity/claims/applicence
AppEstablishmentKey     http://schemas.rm.com/identity/claims/appestablishmentkey
AppUserId   http://schemas.rm.com/identity/claims/appuserid

As a result of this, Rails raises exception on line 43 of your code:
licence = Hash[licence_str[1..-2].split('|').map{|kv|

This commit fixes it.

If you need more information or full log that contains exception, feel free to drop me a line.

P.S. This code is probably not 100% perfect and I assume that there would be a more elegant solution. I'm relatively new to Ruby On Rails and study it ATM.

Thanks!
